### PR TITLE
Wrap in init()

### DIFF
--- a/comment.lua
+++ b/comment.lua
@@ -104,7 +104,10 @@ function string.starts(String,Start)
     return string.sub(String,1,string.len(Start))==Start
 end
 
-MakeCommand("comment", "comment.comment")
-BindKey("Alt-/", "comment.comment")
+function init()
+    MakeCommand("comment", "comment.comment")
+    BindKey("Alt-/", "comment.comment")
 
-AddRuntimeFile("comment", "help", "help/comment-plugin.md")
+    AddRuntimeFile("comment", "help", "help/comment-plugin.md")
+end
+


### PR DESCRIPTION
This was causing an error where when launching micro it would throw an error at these lines trying to call non-function object.
Wraping them in an init() seems to solve the issue and keep the functionality.